### PR TITLE
Fix variable names in edit dataset

### DIFF
--- a/edit_dataset.py
+++ b/edit_dataset.py
@@ -50,17 +50,17 @@ class EditDataset(Dataset):
 
     def __getitem__(self, i: int) -> dict[str, Any]:
         name, seeds = self.seeds[i]
-        propt_dir = Path(self.path, name)
+        prompt_dir = Path(self.path, name)
         seed = seeds[torch.randint(0, len(seeds), ()).item()]
-        with open(propt_dir.joinpath("prompt.json")) as fp:
+        with open(prompt_dir.joinpath("prompt.json")) as fp:
             prompt = json.load(fp)["edit"]
 
-        image_0 = Image.open(propt_dir.joinpath(f"{seed}_0.jpg"))
-        image_1 = Image.open(propt_dir.joinpath(f"{seed}_1.jpg"))
+        image_0 = Image.open(prompt_dir.joinpath(f"{seed}_0.jpg"))
+        image_1 = Image.open(prompt_dir.joinpath(f"{seed}_1.jpg"))
 
-        reize_res = torch.randint(self.min_resize_res, self.max_resize_res + 1, ()).item()
-        image_0 = image_0.resize((reize_res, reize_res), Image.Resampling.LANCZOS)
-        image_1 = image_1.resize((reize_res, reize_res), Image.Resampling.LANCZOS)
+        resize_res = torch.randint(self.min_resize_res, self.max_resize_res + 1, ()).item()
+        image_0 = image_0.resize((resize_res, resize_res), Image.Resampling.LANCZOS)
+        image_1 = image_1.resize((resize_res, resize_res), Image.Resampling.LANCZOS)
 
         image_0 = rearrange(2 * torch.tensor(np.array(image_0)).float() / 255 - 1, "h w c -> c h w")
         image_1 = rearrange(2 * torch.tensor(np.array(image_1)).float() / 255 - 1, "h w c -> c h w")
@@ -103,18 +103,18 @@ class EditDatasetEval(Dataset):
 
     def __getitem__(self, i: int) -> dict[str, Any]:
         name, seeds = self.seeds[i]
-        propt_dir = Path(self.path, name)
+        prompt_dir = Path(self.path, name)
         seed = seeds[torch.randint(0, len(seeds), ()).item()]
-        with open(propt_dir.joinpath("prompt.json")) as fp:
+        with open(prompt_dir.joinpath("prompt.json")) as fp:
             prompt = json.load(fp)
             edit = prompt["edit"]
             input_prompt = prompt["input"]
             output_prompt = prompt["output"]
 
-        image_0 = Image.open(propt_dir.joinpath(f"{seed}_0.jpg"))
+        image_0 = Image.open(prompt_dir.joinpath(f"{seed}_0.jpg"))
 
-        reize_res = torch.randint(self.res, self.res + 1, ()).item()
-        image_0 = image_0.resize((reize_res, reize_res), Image.Resampling.LANCZOS)
+        resize_res = torch.randint(self.res, self.res + 1, ()).item()
+        image_0 = image_0.resize((resize_res, resize_res), Image.Resampling.LANCZOS)
 
         image_0 = rearrange(2 * torch.tensor(np.array(image_0)).float() / 255 - 1, "h w c -> c h w")
 


### PR DESCRIPTION
## Summary
- use `prompt_dir` consistently in dataset classes
- rename `resize_res` var for clarity
- run flake8 and pytest (fails: ModuleNotFoundError)

## Testing
- `flake8 edit_dataset.py`
- `pytest stable_diffusion/scripts/tests/test_watermark.py -q` *(fails: ModuleNotFoundError)*


------
https://chatgpt.com/codex/tasks/task_e_6841e2ce6c08832e807fc803441e9e62

## Summary by Sourcery

Standardize variable naming in edit_dataset classes for clarity and consistency

Enhancements:
- Rename misnamed propt_dir variable to prompt_dir across both dataset implementations
- Correct typo reize_res to resize_res when determining resize resolution