### PR TITLE
Fix dataset script paths in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Input prompts should closely match the distribution of input prompts used to gen
 
 The next step is to finetune a large language model on the manually written instructions/outputs to generate edit instructions and edited caption from a new input caption. For this, we finetune GPT-3's Davinci model via the OpenAI API, although other language models could be used.
 
-To prepare training data for GPT-3, one must first create an OpenAI developer account to access the needed APIs, and [set up the API keys on your local device](https://beta.openai.com/docs/api-reference/introduction). Also, run the `prompts/prepare_for_gpt.py` script, which forms the prompts into the correct format by concatenating instructions and captions and adding delimiters and stop sequences.
+To prepare training data for GPT-3, one must first create an OpenAI developer account to access the needed APIs, and [set up the API keys on your local device](https://beta.openai.com/docs/api-reference/introduction). Also, run the `dataset_creation/prepare_for_gpt.py` script, which forms the prompts into the correct format by concatenating instructions and captions and adding delimiters and stop sequences.
 
 ```bash
 python dataset_creation/prepare_for_gpt.py --input-path data/human-written-prompts.jsonl --output-path data/human-written-prompts-for-gpt.jsonl
@@ -125,7 +125,7 @@ python prompt_app.py --openai-api-key OPENAI_KEY --openai-model OPENAI_MODEL_NAM
 
 #### (1.3) Generate a large dataset of captions and instructions
 
-We now use the finetuned GPT-3 model to generate a large dataset. Our dataset cost thousands of dollars to create. See `prompts/gen_instructions_and_captions.py` for the script which generates these examples. We recommend first generating a small number of examples (by setting a low value of `--num-samples`) and gradually increasing the scale to ensure the results are working as desired before increasing scale.
+We now use the finetuned GPT-3 model to generate a large dataset. Our dataset cost thousands of dollars to create. See `dataset_creation/generate_txt_dataset.py` for the script which generates these examples. We recommend first generating a small number of examples (by setting a low value of `--num-samples`) and gradually increasing the scale to ensure the results are working as desired before increasing scale.
 
 ```bash
 python dataset_creation/generate_txt_dataset.py --openai-api-key OPENAI_KEY --openai-model OPENAI_MODEL_NAME


### PR DESCRIPTION
## Summary
- fix README references to dataset scripts

## Testing
- `pytest stable_diffusion/scripts/tests/test_watermark.py -q` *(fails: ModuleNotFoundError: No module named 'imwatermark')*


------
https://chatgpt.com/codex/tasks/task_e_6841e2d2a5e0832eae5369256a7f6f23